### PR TITLE
Context menu to add additional references

### DIFF
--- a/src/brainglobe_napari/atlas_viewer_widget.py
+++ b/src/brainglobe_napari/atlas_viewer_widget.py
@@ -234,7 +234,10 @@ class AtlasViewerWidget(QWidget):
     def _on_context_menu_requested(self, position):
         if self._selected_atlas_name in get_downloaded_atlases():
             metadata = read_atlas_metadata_from_file(self._selected_atlas_name)
-            if metadata["additional_references"]:
+            if (
+                "additional_references" in metadata.keys()
+                and metadata["additional_references"]
+            ):
                 global_position = self.atlas_table_view.viewport().mapToGlobal(
                     position
                 )

--- a/src/brainglobe_napari/napari_atlas_representation.py
+++ b/src/brainglobe_napari/napari_atlas_representation.py
@@ -65,3 +65,10 @@ class NapariAtlasRepresentation:
                 [[float(c) / 255 for c in color]], len(points), axis=0
             )
         self.viewer.add_surface((points, cells), **viewer_kwargs)
+
+    def add_additional_reference(self, additional_reference_key: str):
+        self.viewer.add_image(
+            self.bg_atlas.additional_references[additional_reference_key],
+            scale=self.bg_atlas.resolution,
+            name=f"{self.bg_atlas.atlas_name}_{additional_reference_key}_reference",
+        )

--- a/src/brainglobe_napari/tests/conftest.py
+++ b/src/brainglobe_napari/tests/conftest.py
@@ -52,7 +52,7 @@ def mock_brainglobe_user_folders(monkeypatch):
 @pytest.fixture
 def double_click_on_view(qtbot):
     def inner_double_click_on_view(view, index):
-        viewport_index = view.visualRect(index).center()
+        viewport_index_position = view.visualRect(index).center()
 
         # weirdly, to correctly emulate a double-click
         # you need to click first. Also, note that the view
@@ -60,12 +60,12 @@ def double_click_on_view(qtbot):
         qtbot.mouseClick(
             view.viewport(),
             Qt.MouseButton.LeftButton,
-            pos=viewport_index,
+            pos=viewport_index_position,
         )
         qtbot.mouseDClick(
             view.viewport(),
             Qt.MouseButton.LeftButton,
-            pos=viewport_index,
+            pos=viewport_index_position,
         )
 
     return inner_double_click_on_view

--- a/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
+++ b/src/brainglobe_napari/tests/test_atlas_viewer_widget.py
@@ -89,8 +89,8 @@ def test_double_click_on_locally_available_atlas_row(
 @pytest.mark.parametrize(
     "row, expected_atlas_name",
     [
-        (1, "allen_mouse_100um"),  # not part of downloaded test data
-        (5, "mpin_zfish_1um"),  # not part of downloaded test data
+        (1, "allen_mouse_100um"),  # part of downloaded test data
+        (6, "allen_human_500um"),  # not part of downloaded test data
     ],
 )
 def test_double_click_on_not_yet_downloaded_atlas_row(
@@ -150,7 +150,7 @@ def test_structure_row_double_clicked(
     "row, expected_visibility",
     [
         (4, True),  # allen_mouse_100um is part of downloaded test data
-        (5, False),  # mpin_fish_1um is not part of download test data
+        (6, False),  # allen_human_500um is not part of download test data
     ],
 )
 def test_add_structure_visibility(make_atlas_viewer, row, expected_visibility):
@@ -163,24 +163,28 @@ def test_add_structure_visibility(make_atlas_viewer, row, expected_visibility):
 
 
 def test_get_tooltip_downloaded():
+    """Check tooltip on an example in the downloaded test data"""
     tooltip_text = AtlasViewerWidget.get_tooltip_text("example_mouse_100um")
     assert "example_mouse" in tooltip_text
     assert "add to viewer" in tooltip_text
 
 
 def test_get_tooltip_not_locally_available():
-    tooltip_text = AtlasViewerWidget.get_tooltip_text("mpin_zfish_1um")
-    assert "mpin_zfish_1um" in tooltip_text
+    """Check tooltip on an example in not-downloaded test data"""
+    tooltip_text = AtlasViewerWidget.get_tooltip_text("allen_human_500um")
+    assert "allen_human_500um" in tooltip_text
     assert "double-click to download" in tooltip_text
 
 
 def test_get_tooltip_invalid_name():
+    """Check tooltip on non-existent test data"""
     with pytest.raises(ValueError) as e:
         _ = AtlasViewerWidget.get_tooltip_text("wrong_atlas_name")
         assert "invalid atlas name" in e
 
 
 def test_hover_atlas_table_view(make_atlas_viewer, mocker, qtbot):
+    """Check tooltip is called when hovering over view"""
     _, atlas_viewer = make_atlas_viewer
     view = atlas_viewer.atlas_table_view
     index = view.model().index(2, 1)

--- a/src/brainglobe_napari/tests/test_napari_atlas_representation.py
+++ b/src/brainglobe_napari/tests/test_napari_atlas_representation.py
@@ -107,3 +107,19 @@ def test_structure_color(make_napari_viewer):
 
     for a, e in zip(actual_rgb, expected_RGB):
         assert a * 255 == e
+
+
+def test_add_additional_reference(make_napari_viewer, mocker):
+    viewer = make_napari_viewer()
+    atlas_name = "mpin_zfish_1um"
+    additional_reference_name = "GAD1b"
+    atlas = BrainGlobeAtlas(atlas_name=atlas_name)
+
+    atlas_representation = NapariAtlasRepresentation(atlas, viewer)
+    atlas_representation.add_additional_reference(additional_reference_name)
+
+    assert len(viewer.layers) == 1
+    assert (
+        viewer.layers[0].name
+        == f"{atlas_name}_{additional_reference_name}_reference"
+    )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The main components of atlases we'd like to add as layers include additional reference images.

**What does this PR do?**
Adds functionality to add additional reference images to napari (if the atlas has them).
This is achieved by a custom context menu which can be opened via a right-click on the atlas table view.
In order to test this well, we now have the `mpin_zfish_1um` atlas as part of the downloaded test data (as it is the smallest atlas that has additional references, AFAIK).

(Some improving of testing docstrings and variable names are included in this PR)

## References

Closes #6 

## How has this PR been tested?

* A new test for the napari atlas representation part of the new functionality is added. 
* Emulating a right-click to open the context menu was tricky in `qtbot` and has therefore been kicked down the line.

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

In the future, yes. No high-level documentation for this plugin exists yet.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
