### PR TITLE
depend non-optionally on latest napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "napari>=0.4.18",
     "bg-atlasapi",
     "numpy",
     "qtpy",
@@ -52,7 +53,6 @@ dev = [
   "pre-commit",
   "ruff",
   "setuptools_scm",
-  "napari",
   "pyqt5"
 ]
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Older versions of napari have [a bug that affects this repo](https://github.com/brainglobe/brainrender-napari/pull/31#issuecomment-1611678666).

**What does this PR do?**
Moves napari to non-optional dependencies, and requires napari >=0.4.18

## References

Closes #35 

## How has this PR been tested?

I've been running tests locally on napari 0.4.18 RCs for a while, and presumably the CI too (since the release of 0.4.18 a few weeks ago)

## Is this a breaking change?

In the sense that this may not be installable on older napari version now, yes.

## Does this PR require an update to the documentation?

Nope.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
