### PR TITLE
add name to structure tree view

### DIFF
--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -29,6 +29,26 @@ def test_download_confirmed_refreshes_view(brainrender_widget, mocker):
     )
 
 
+def test_not_downloaded_atlas_hides_checkbox(brainrender_widget, mocker):
+    show_structure_names_hide_mock = mocker.patch(
+        "brainrender_napari.brainrender_widget.QCheckBox.hide"
+    )
+    brainrender_widget._on_atlas_selection_changed(
+        "allen_mouse_10um"
+    )  # not part of downloaded data
+    show_structure_names_hide_mock.assert_called_once()
+
+
+def test_downloaded_atlas_shows_checkbox(brainrender_widget, mocker):
+    show_structure_names_show_mock = mocker.patch(
+        "brainrender_napari.brainrender_widget.QCheckBox.show"
+    )
+    brainrender_widget._on_atlas_selection_changed(
+        "example_mouse_100um"
+    )  # part of downloaded data
+    show_structure_names_show_mock.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "expected_atlas_name",
     [
@@ -91,3 +111,19 @@ def test_add_additional_reference_selected(brainrender_widget, mocker):
     add_additional_reference_mock.assert_called_once_with(
         additional_reference_name
     )
+
+
+def test_show_structures_checkbox(brainrender_widget, mocker):
+    structure_view_refresh_mock = mocker.patch(
+        "brainrender_napari.brainrender_widget" ".StructureView.refresh"
+    )
+    brainrender_widget.atlas_table_view.selectRow(
+        0
+    )  # example_mouse_100um is in row 0
+    structure_view_refresh_mock.assert_called_with(
+        "example_mouse_100um", False
+    )
+
+    brainrender_widget.show_structure_names.click()
+    assert structure_view_refresh_mock.call_count == 2
+    structure_view_refresh_mock.assert_called_with("example_mouse_100um", True)

--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -24,7 +24,9 @@ def test_download_confirmed_refreshes_view(brainrender_widget, mocker):
     brainrender_widget.atlas_table_view.download_atlas_confirmed.emit(
         "allen_mouse_10um"
     )
-    structure_view_refresh_mock.assert_called_once_with("allen_mouse_10um")
+    structure_view_refresh_mock.assert_called_once_with(
+        "allen_mouse_10um", False
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_structure_view.py
+++ b/tests/test_unit/test_structure_view.py
@@ -45,6 +45,17 @@ def test_structure_view_visibility(
     assert structure_view.isVisible() == expected_visibility
 
 
+@pytest.mark.parametrize("show_structure_names", [True, False])
+def test_structure_view_column_visibility(
+    structure_view, show_structure_names
+):
+    """Checks the column visibility for a visible structure view"""
+    structure_view.refresh("allen_mouse_100um", show_structure_names)
+    assert not structure_view.isColumnHidden(0)  # acronym is always visible
+    assert structure_view.isColumnHidden(2)  # id column is always hidden
+    assert structure_view.isColumnHidden(1) != show_structure_names
+
+
 def test_double_click_on_structure_row(
     structure_view, double_click_on_view, qtbot
 ):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We'd like to see the names of the structures in the tree view, not just the acronyms

**What does this PR do?**
Alternative, simpler-to-implement solution to a toggle between structure acronyms and names: acronyms are always shown, and names can be shown/hidden with a checkbox.

For the more difficult implementation
- make the model editable by reimplementing`setData` (but make sure the user can't edit)
or
- replace model entirely anytime things are toggled. This would work OK if we managed to remember the expanded indices, but this is tricky because we are left with dangling pointers on model replacement. See an attempt at this on
the [`complex-structure-tree-view` branch](https://github.com/brainglobe/brainrender-napari/tree/complex-structure-tree-view).

## References

Closes #47 

## How has this PR been tested?

Tests for the new checkbox functionality have been added.

## Is this a breaking change?

Nope.

## Does this PR require an update to the documentation?

Nope

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
