### PR TITLE
offload atlas downloading to separate thread

### DIFF
--- a/tests/test_unit/test_atlas_table_view.py
+++ b/tests/test_unit/test_atlas_table_view.py
@@ -199,7 +199,8 @@ def test_download_confirmed_callback(atlas_table_view, qtbot):
     )  # sanity check that local copy is gone
 
     with qtbot.waitSignal(
-        atlas_table_view.download_atlas_confirmed
+        atlas_table_view.download_atlas_confirmed,
+        timeout=15000,  # assumes atlas can be installed in 15 secs!
     ) as download_atlas_confirmed_signal:
         model_index = atlas_table_view.model().index(0, 0)
         atlas_table_view.setCurrentIndex(model_index)

--- a/tests/test_unit/test_atlas_table_view.py
+++ b/tests/test_unit/test_atlas_table_view.py
@@ -200,7 +200,7 @@ def test_download_confirmed_callback(atlas_table_view, qtbot):
 
     with qtbot.waitSignal(
         atlas_table_view.download_atlas_confirmed,
-        timeout=15000,  # assumes atlas can be installed in 15 secs!
+        timeout=150000,  # assumes atlas can be installed in 2.5 minutes!
     ) as download_atlas_confirmed_signal:
         model_index = atlas_table_view.model().index(0, 0)
         atlas_table_view.setCurrentIndex(model_index)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Downloading an atlas should not block the napari viewer

**What does this PR do?**
Offloads the atlas downloading to a separate thread.

## References

Closes #7 

## How has this PR been tested?
Existing unit test adapted to wait for worker to finish.

## Is this a breaking change?

Nope.

## Does this PR require an update to the documentation?

n/a

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
