### PR TITLE
add tooltip hints to UI

### DIFF
--- a/brainrender_napari/brainrender_widget.py
+++ b/brainrender_napari/brainrender_widget.py
@@ -12,6 +12,7 @@ from bg_atlasapi.list_atlases import get_downloaded_atlases
 from napari.viewer import Viewer
 from qtpy.QtWidgets import (
     QCheckBox,
+    QGroupBox,
     QVBoxLayout,
     QWidget,
 )
@@ -49,8 +50,16 @@ class BrainrenderWidget(QWidget):
 
         self.structure_view = StructureView(parent=self)
 
-        # add widgets to the layout
-        self.layout().addWidget(self.atlas_table_view)
+        # add widgets to the layout as group boxes
+        atlas_table_group = QGroupBox("Atlas table view")
+        atlas_table_group.setToolTip(
+            "Double-click on row to download/add annotations and reference\n"
+            "Right-click to add additional reference images (if any exist)"
+        )
+        atlas_table_group.setLayout(QVBoxLayout())
+        atlas_table_group.layout().addWidget(self.atlas_table_view)
+        self.layout().addWidget(atlas_table_group)
+
         self.layout().addWidget(self.show_structure_names)
         self.layout().addWidget(self.structure_view)
 

--- a/brainrender_napari/brainrender_widget.py
+++ b/brainrender_napari/brainrender_widget.py
@@ -54,14 +54,14 @@ class BrainrenderWidget(QWidget):
         self.structure_view = StructureView(parent=self)
 
         # add widgets to the layout as group boxes
-        atlas_table_group = QGroupBox("Atlas table view")
-        atlas_table_group.setToolTip(
+        self.atlas_table_group = QGroupBox("Atlas table view")
+        self.atlas_table_group.setToolTip(
             "Double-click on row to download/add annotations and reference\n"
             "Right-click to add additional reference images (if any exist)"
         )
-        atlas_table_group.setLayout(QVBoxLayout())
-        atlas_table_group.layout().addWidget(self.atlas_table_view)
-        self.layout().addWidget(atlas_table_group)
+        self.atlas_table_group.setLayout(QVBoxLayout())
+        self.atlas_table_group.layout().addWidget(self.atlas_table_view)
+        self.layout().addWidget(self.atlas_table_group)
 
         self.structure_tree_group = QGroupBox("Structures")
         self.structure_tree_group.setToolTip(

--- a/brainrender_napari/brainrender_widget.py
+++ b/brainrender_napari/brainrender_widget.py
@@ -46,6 +46,9 @@ class BrainrenderWidget(QWidget):
         self.show_structure_names = QCheckBox()
         self.show_structure_names.setChecked(False)
         self.show_structure_names.setText("Show structure names")
+        self.show_structure_names.setToolTip(
+            "Tick to show structure names, untick to show acronyms only."
+        )
         self.show_structure_names.hide()
 
         self.structure_view = StructureView(parent=self)
@@ -60,8 +63,15 @@ class BrainrenderWidget(QWidget):
         atlas_table_group.layout().addWidget(self.atlas_table_view)
         self.layout().addWidget(atlas_table_group)
 
-        self.layout().addWidget(self.show_structure_names)
-        self.layout().addWidget(self.structure_view)
+        self.structure_tree_group = QGroupBox("Structures")
+        self.structure_tree_group.setToolTip(
+            "Double-click on structure to add to viewer"
+        )
+        self.structure_tree_group.setLayout(QVBoxLayout())
+        self.structure_tree_group.layout().addWidget(self.show_structure_names)
+        self.structure_tree_group.layout().addWidget(self.structure_view)
+        self.structure_tree_group.hide()
+        self.layout().addWidget(self.structure_tree_group)
 
         # connect atlas view widget signals
         self.atlas_table_view.download_atlas_confirmed.connect(
@@ -116,10 +126,9 @@ class BrainrenderWidget(QWidget):
         """Refreshes the structure view to match the changed atlas selection"""
         show_structure_names = self.show_structure_names.isChecked()
         self.structure_view.refresh(atlas_name, show_structure_names)
-        if atlas_name in get_downloaded_atlases():
-            self.show_structure_names.show()
-        else:
-            self.show_structure_names.hide()
+        is_downloaded = atlas_name in get_downloaded_atlases()
+        self.show_structure_names.setVisible(is_downloaded)
+        self.structure_tree_group.setVisible(is_downloaded)
 
     def _on_add_atlas_requested(self, atlas_name: str):
         """Add reference and annotation as napari atlas representation"""

--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -29,6 +29,26 @@ def test_download_confirmed_refreshes_view(brainrender_widget, mocker):
     )
 
 
+def test_not_downloaded_atlas_hides_checkbox(brainrender_widget, mocker):
+    show_structure_names_hide_mock = mocker.patch(
+        "brainrender_napari.brainrender_widget.QCheckBox.hide"
+    )
+    brainrender_widget._on_atlas_selection_changed(
+        "allen_mouse_10um"
+    )  # not part of downloaded data
+    show_structure_names_hide_mock.assert_called_once()
+
+
+def test_downloaded_atlas_shows_checkbox(brainrender_widget, mocker):
+    show_structure_names_show_mock = mocker.patch(
+        "brainrender_napari.brainrender_widget.QCheckBox.show"
+    )
+    brainrender_widget._on_atlas_selection_changed(
+        "example_mouse_100um"
+    )  # part of downloaded data
+    show_structure_names_show_mock.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "expected_atlas_name",
     [

--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -29,26 +29,6 @@ def test_download_confirmed_refreshes_view(brainrender_widget, mocker):
     )
 
 
-def test_not_downloaded_atlas_hides_checkbox(brainrender_widget, mocker):
-    show_structure_names_hide_mock = mocker.patch(
-        "brainrender_napari.brainrender_widget.QCheckBox.hide"
-    )
-    brainrender_widget._on_atlas_selection_changed(
-        "allen_mouse_10um"
-    )  # not part of downloaded data
-    show_structure_names_hide_mock.assert_called_once()
-
-
-def test_downloaded_atlas_shows_checkbox(brainrender_widget, mocker):
-    show_structure_names_show_mock = mocker.patch(
-        "brainrender_napari.brainrender_widget.QCheckBox.show"
-    )
-    brainrender_widget._on_atlas_selection_changed(
-        "example_mouse_100um"
-    )  # part of downloaded data
-    show_structure_names_show_mock.assert_called_once()
-
-
 @pytest.mark.parametrize(
     "expected_atlas_name",
     [

--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -124,3 +124,27 @@ def test_show_structures_checkbox(brainrender_widget, mocker):
     brainrender_widget.show_structure_names.click()
     assert structure_view_refresh_mock.call_count == 2
     structure_view_refresh_mock.assert_called_with("example_mouse_100um", True)
+
+
+def test_structure_view_tooltip(brainrender_widget):
+    for expected_keyword in ["double-click", "structure", "viewer"]:
+        assert (
+            expected_keyword
+            in brainrender_widget.structure_tree_group.toolTip().lower()
+        )
+
+
+def test_atlas_table_view_tooltip(brainrender_widget):
+    for expected_keyword in [
+        "double-click",
+        "download",
+        "add",
+        "annotations",
+        "reference",
+        "right-click",
+        "additional",
+    ]:
+        assert (
+            expected_keyword
+            in brainrender_widget.atlas_table_group.toolTip().lower()
+        )

--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -29,24 +29,21 @@ def test_download_confirmed_refreshes_view(brainrender_widget, mocker):
     )
 
 
-def test_not_downloaded_atlas_hides_checkbox(brainrender_widget, mocker):
-    show_structure_names_hide_mock = mocker.patch(
-        "brainrender_napari.brainrender_widget.QCheckBox.hide"
+@pytest.mark.parametrize(
+    "expected_visibility, atlas",
+    [
+        (True, "example_mouse_100um"),  # part of downloaded data
+        (False, "allen_mouse_10um"),  # not part of downloaded data
+    ],
+)
+def test_checkbox_visibility(
+    brainrender_widget, mocker, expected_visibility, atlas
+):
+    checkbox_visibility_mock = mocker.patch(
+        "brainrender_napari.brainrender_widget.QCheckBox.setVisible"
     )
-    brainrender_widget._on_atlas_selection_changed(
-        "allen_mouse_10um"
-    )  # not part of downloaded data
-    show_structure_names_hide_mock.assert_called_once()
-
-
-def test_downloaded_atlas_shows_checkbox(brainrender_widget, mocker):
-    show_structure_names_show_mock = mocker.patch(
-        "brainrender_napari.brainrender_widget.QCheckBox.show"
-    )
-    brainrender_widget._on_atlas_selection_changed(
-        "example_mouse_100um"
-    )  # part of downloaded data
-    show_structure_names_show_mock.assert_called_once()
+    brainrender_widget._on_atlas_selection_changed(atlas)
+    checkbox_visibility_mock.assert_called_once_with(expected_visibility)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
It should be as easy as possible for users to use `brainrender-napari`

**What does this PR do?**
* Adds tooltips for all widgets, containing simple user instructions for each of them
* Divides the atlas and the structure widgets into two groups, so it's clearer which belongs to which.

## References

Closes #52 

## How has this PR been tested?

* new tests for tooltips
* tests pass locally and on CI
* visual inspection by hovering over widgets

## Is this a breaking change?
No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
