### PR TITLE
Fix structure view crash

### DIFF
--- a/brainrender_napari/widgets/structure_view.py
+++ b/brainrender_napari/widgets/structure_view.py
@@ -191,12 +191,13 @@ class StructureView(QTreeView):
             self.hide()
         self.setCurrentIndex(QModelIndex())
 
-    def selected_structure_name(self) -> str:
+    def selected_structure_acronym(self) -> str:
         """A single place to get a valid selected structure"""
         selected_index = self.selectionModel().currentIndex()
         assert selected_index.isValid()
-        selected_structure_name = self.model().data(selected_index)
-        return selected_structure_name
+        acronym_index = selected_index.siblingAtColumn(0)
+        selected_structure_acronym = self.model().data(acronym_index)
+        return selected_structure_acronym
 
     def _on_row_double_clicked(self):
-        self.add_structure_requested.emit(self.selected_structure_name())
+        self.add_structure_requested.emit(self.selected_structure_acronym())

--- a/tests/test_unit/test_structure_view.py
+++ b/tests/test_unit/test_structure_view.py
@@ -56,8 +56,12 @@ def test_structure_view_column_visibility(
     assert structure_view.isColumnHidden(1) != show_structure_names
 
 
+@pytest.mark.parametrize(
+    "column_clicked",
+    [0, 1],  # we should be able to click on either column with the same result
+)
 def test_double_click_on_structure_row(
-    structure_view, double_click_on_view, qtbot
+    structure_view, double_click_on_view, qtbot, column_clicked
 ):
     """Checks that expected signal is emitted when
     double-clicking on a row in the structure view"""
@@ -65,7 +69,10 @@ def test_double_click_on_structure_row(
 
     root_index = structure_view.rootIndex()
     root_mesh_index = structure_view.model().index(0, 0, root_index)
-    vs_mesh_index = structure_view.model().index(0, 0, root_mesh_index)
+    assert root_mesh_index.isValid()
+    vs_mesh_index = structure_view.model().index(
+        0, column_clicked, root_mesh_index
+    )
     assert vs_mesh_index.isValid()
     structure_view.setCurrentIndex(vs_mesh_index)
     with qtbot.waitSignal(

--- a/tests/test_unit/test_structure_view.py
+++ b/tests/test_unit/test_structure_view.py
@@ -8,17 +8,23 @@ def structure_view(qtbot) -> StructureView:
     return StructureView()
 
 
-def test_structure_view_valid_selection(structure_view):
+@pytest.mark.parametrize(
+    "column_clicked",
+    [0, 1],  # we should be able to click on either column with the same result
+)
+def test_structure_view_valid_selection(structure_view, column_clicked):
     """Checks that the correct structure name is returned
     if a valid structure view index is selected."""
     structure_view.refresh("allen_mouse_100um")
 
     root_index = structure_view.rootIndex()
     root_mesh_index = structure_view.model().index(0, 0, root_index)
-    vs_mesh_index = structure_view.model().index(0, 0, root_mesh_index)
+    vs_mesh_index = structure_view.model().index(
+        0, column_clicked, root_mesh_index
+    )
     assert vs_mesh_index.isValid()
     structure_view.setCurrentIndex(vs_mesh_index)
-    assert structure_view.selected_structure_name() == "VS"
+    assert structure_view.selected_structure_acronym() == "VS"
 
 
 def test_structure_view_invalid_selection(structure_view):
@@ -26,7 +32,7 @@ def test_structure_view_invalid_selection(structure_view):
     if current index is invalid."""
     structure_view.refresh("allen_mouse_100um")
     with pytest.raises(AssertionError):
-        structure_view.selected_structure_name()
+        structure_view.selected_structure_acronym()
 
 
 @pytest.mark.parametrize(
@@ -64,8 +70,8 @@ def test_double_click_on_structure_row(
     structure_view, double_click_on_view, qtbot, column_clicked
 ):
     """Checks that expected signal is emitted when
-    double-clicking on a row in the structure view"""
-    structure_view.refresh("allen_mouse_100um")
+    double-clicking on a row (indpendent of column) in the structure view"""
+    structure_view.refresh("allen_mouse_100um", True)
 
     root_index = structure_view.rootIndex()
     root_mesh_index = structure_view.model().index(0, 0, root_index)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Double-click on structure _name_ (not acronym) causes a crash, because name is passed as a key to a dictionary with acronyms as keys.

**What does this PR do?**
Ensures `structure_view.selected_structure_acronym` (renamed in this PR) always returns the acronym even when the index the users clicks on is the name.

## References

Fixes #76 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
