### PR TITLE
improve 3D brain region view tooltip

### DIFF
--- a/brainrender_napari/brainrender_widget.py
+++ b/brainrender_napari/brainrender_widget.py
@@ -65,7 +65,10 @@ class BrainrenderWidget(QWidget):
 
         self.structure_tree_group = QGroupBox("3D Atlas region meshes")
         self.structure_tree_group.setToolTip(
-            "Double-click on a region to add to viewer"
+            "Double-click on an atlas region to add its mesh to the viewer.\n"
+            "Meshes will only show if the display is set to 3D.\n"
+            "Toggle 2D/3D display using the square/cube icon on the\n"
+            "lower left of the napari window."
         )
         self.structure_tree_group.setLayout(QVBoxLayout())
         self.structure_tree_group.layout().addWidget(self.show_structure_names)

--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -131,7 +131,14 @@ def test_show_structures_checkbox(brainrender_widget, mocker):
 
 
 def test_structure_view_tooltip(brainrender_widget):
-    for expected_keyword in ["double-click", "region", "viewer"]:
+    for expected_keyword in [
+        "double-click",
+        "atlas region",
+        "3d",
+        "display",
+        "toggle",
+        "viewer",
+    ]:
         assert (
             expected_keyword
             in brainrender_widget.structure_tree_group.toolTip().lower()

--- a/tests/test_integration/test_brainrender_widget.py
+++ b/tests/test_integration/test_brainrender_widget.py
@@ -134,7 +134,9 @@ def test_structure_view_tooltip(brainrender_widget):
     for expected_keyword in [
         "double-click",
         "atlas region",
+        "add",
         "3d",
+        "mesh",
         "display",
         "toggle",
         "viewer",


### PR DESCRIPTION
- [x] Depends on #82 being merged first!

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
It may not be obvious that meshes are only really visible in a 3D view.

**What does this PR do?**
Specifies the above in the mesh tooltip.

## References
Closes #81 (in conjunction with docs improvements and #82 )

## How has this PR been tested?
Tests pass locally and on CI.
`test_brainrender_widget.test_structure_view_tooltip()` has been adapted to include additional keywords for the expanded tooltip.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
