### PR TITLE
drop py3.8, support 3.11

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "brainrender-napari"
 authors = [{name = "Alessandro Felder", email= "a.felder@ucl.ac.uk"}]
 description = "A napari plugin to render BrainGlobe atlases and associated data as layers."
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version"]
 
 license = {text = "BSD-3-Clause"}
@@ -14,9 +14,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: BSD License",
     "Topic :: Scientific/Engineering :: Image Processing",
@@ -76,7 +76,7 @@ exclude = ["tests", "docs*"]
 addopts = "--cov=brainrender_napari"
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310', 'py311']
 skip-string-normalization = false
 line-length = 79
 
@@ -101,7 +101,7 @@ select = ["I", "E", "F"]
 fix = true
 
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-*"
+build = "cp39-* cp310- cp311-*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
@@ -109,14 +109,14 @@ archs = ["x86_64", "arm64"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{38,39,310}
+envlist = py{39,310,311}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{39,310,311}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
We adhere to NEP 29 (and support for 3.8 was causing me problems cross-Python-version compatibility with `importlib.resources`

**What does this PR do?**
Drop Python 3.8 support and optimistically support 3.11 (napari supports 3.11 for a few months now, I think).

## References

-

## How has this PR been tested?

## Is this a breaking change?

Yes, for Python 3.8 users.

## Does this PR require an update to the documentation?

Created TODO so we officialise our adherence to NEP 29.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
