### PR TITLE
Update how Qt is installed on CI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,14 +46,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # these libraries enable testing on Qt on linux
-      - uses: tlambert03/setup-qt-libs@v1
-
-      # strategy borrowed from vispy for installing opengl libs on windows
-      - name: Install Windows OpenGL
-        if: runner.os == 'Windows'
-        run: |
-          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
-          powershell gl-ci-helpers/appveyor/install_opengl.ps1
+      - uses: pyvista/setup-headless-display-action@v2
+        with:
+          qt: true
 
       # cache atlases needed by the tests
       - name: Cache Atlases


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`pytest` currently throws a fatal error, possibly related to Qt

**What does this PR do?**

Follows the [approach to getting Qt on CI suggested on the napari zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/opengl.20on.20CI), and implemented in https://github.com/brainglobe/brainglobe-utils/pull/13/checks, in the hope that the tests run and pass again.

## References
Closes #116 

## How has this PR been tested?
CI is now passing again

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No

## Checklist:

- [na] The code has been tested locally
- [na] Tests have been added to cover all new functionality (unit & integration)
- [na] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
