### PR TITLE
bg-atlasapi -> brainglobe-atlasapi

### DIFF
--- a/brainrender_napari/brainrender_widget.py
+++ b/brainrender_napari/brainrender_widget.py
@@ -8,8 +8,8 @@ shown in a table view using the Qt model/view framework
 Users can add the atlas images/structures as layers to the viewer.
 """
 
-from bg_atlasapi import BrainGlobeAtlas
-from bg_atlasapi.list_atlases import get_downloaded_atlases
+from brainglobe_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
 from napari.viewer import Viewer
 from qtpy.QtWidgets import (
     QCheckBox,

--- a/brainrender_napari/data_models/atlas_table_model.py
+++ b/brainrender_napari/data_models/atlas_table_model.py
@@ -1,4 +1,4 @@
-from bg_atlasapi.list_atlases import (
+from brainglobe_atlasapi.list_atlases import (
     get_all_atlases_lastversions,
     get_atlases_lastversions,
     get_local_atlas_version,

--- a/brainrender_napari/data_models/structure_tree_model.py
+++ b/brainrender_napari/data_models/structure_tree_model.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from bg_atlasapi.structure_tree_util import get_structures_tree
+from brainglobe_atlasapi.structure_tree_util import get_structures_tree
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
 from qtpy.QtGui import QStandardItem
 

--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import numpy as np
-from bg_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi import BrainGlobeAtlas
 from meshio import Mesh
 from napari.settings import get_settings
 from napari.viewer import Viewer

--- a/brainrender_napari/utils/formatting.py
+++ b/brainrender_napari/utils/formatting.py
@@ -1,4 +1,4 @@
-from bg_atlasapi.list_atlases import get_all_atlases_lastversions
+from brainglobe_atlasapi.list_atlases import get_all_atlases_lastversions
 
 
 def format_atlas_name(name: str) -> str:

--- a/brainrender_napari/utils/load_user_data.py
+++ b/brainrender_napari/utils/load_user_data.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from bg_atlasapi.list_atlases import get_local_atlas_version
+from brainglobe_atlasapi.list_atlases import get_local_atlas_version
 
 
 def read_atlas_metadata_from_file(atlas_name: str):

--- a/brainrender_napari/widgets/atlas_manager_dialog.py
+++ b/brainrender_napari/widgets/atlas_manager_dialog.py
@@ -1,4 +1,4 @@
-from bg_atlasapi.list_atlases import get_all_atlases_lastversions
+from brainglobe_atlasapi.list_atlases import get_all_atlases_lastversions
 from qtpy.QtWidgets import (
     QDialog,
     QHBoxLayout,

--- a/brainrender_napari/widgets/atlas_manager_view.py
+++ b/brainrender_napari/widgets/atlas_manager_view.py
@@ -11,12 +11,12 @@ that any interested observers can connect to.
 
 from typing import Callable
 
-from bg_atlasapi.list_atlases import (
+from brainglobe_atlasapi.list_atlases import (
     get_all_atlases_lastversions,
     get_atlases_lastversions,
     get_downloaded_atlases,
 )
-from bg_atlasapi.update_atlases import install_atlas, update_atlas
+from brainglobe_atlasapi.update_atlases import install_atlas, update_atlas
 from napari.qt import thread_worker
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QTableView, QWidget

--- a/brainrender_napari/widgets/atlas_viewer_view.py
+++ b/brainrender_napari/widgets/atlas_viewer_view.py
@@ -9,7 +9,7 @@ that interested observers can connect to.
 
 from typing import Tuple
 
-from bg_atlasapi.list_atlases import (
+from brainglobe_atlasapi.list_atlases import (
     get_downloaded_atlases,
 )
 from qtpy.QtCore import Qt, Signal

--- a/brainrender_napari/widgets/structure_view.py
+++ b/brainrender_napari/widgets/structure_view.py
@@ -4,8 +4,8 @@ The view is only visible if the atlas is downloaded."""
 
 from typing import Dict, List
 
-from bg_atlasapi.list_atlases import get_downloaded_atlases
-from bg_atlasapi.structure_tree_util import get_structures_tree
+from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
+from brainglobe_atlasapi.structure_tree_util import get_structures_tree
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal
 from qtpy.QtGui import QStandardItem
 from qtpy.QtWidgets import QTreeView, QWidget

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "napari>=0.4.18",
-    "bg-atlasapi",
+    "brainglobe-atlasapi>=2.0.1",
     "numpy",
     "qtpy",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import shutil
 from pathlib import Path
 
 import pytest
-from bg_atlasapi import BrainGlobeAtlas, config, list_atlases
+from brainglobe_atlasapi import BrainGlobeAtlas, config, list_atlases
 from qtpy.QtCore import Qt
 
 

--- a/tests/test_unit/test_atlas_manager_view.py
+++ b/tests/test_unit/test_atlas_manager_view.py
@@ -83,7 +83,7 @@ def test_download_confirmed_callback(atlas_manager_view, qtbot):
     Test setup consists of remembering the expected files and folders
     of a preexisting atlas and then removing them. This allows checking
     that the function triggers the creation of the same local copy
-    of the atlas as the `bg_atlasapi` itself.
+    of the atlas as the `brainglobe_atlasapi` itself.
     """
     atlas_directory = Path.home() / ".brainglobe/example_mouse_100um_v1.2"
     expected_filenames = atlas_directory.iterdir()

--- a/tests/test_unit/test_metadata_reading.py
+++ b/tests/test_unit/test_metadata_reading.py
@@ -1,4 +1,4 @@
-from bg_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi import BrainGlobeAtlas
 
 from brainrender_napari.utils.load_user_data import (
     read_atlas_metadata_from_file,

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -1,5 +1,5 @@
 import pytest
-from bg_atlasapi import BrainGlobeAtlas
+from brainglobe_atlasapi import BrainGlobeAtlas
 from napari.layers import Image, Labels
 from numpy import all, allclose
 from qtpy.QtCore import QEvent, QPoint, Qt


### PR DESCRIPTION
See https://github.com/brainglobe/BrainGlobe/issues/43 |

Bumps our dependence on `bg-atlasapi` to `brainglobe-atlasapi`.