### PR TITLE
reduce test data size and relax test timouts

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,6 +31,7 @@ jobs:
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # Run all supported Python versions on linux
         python-version: ["3.10", "3.11", "3.12"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 from pathlib import Path
@@ -58,13 +59,23 @@ def setup_preexisting_local_atlases():
         ("example_mouse_100um", "v1.2"),
         ("allen_mouse_100um", "v1.2"),
         ("osten_mouse_100um", "v1.1"),
-        ("mpin_zfish_1um", "v1.0"),
     ]
     for atlas_name, version in preexisting_atlases:
         if not Path.exists(
             Path.home() / f".brainglobe/{atlas_name}_{version}"
         ):
             _ = BrainGlobeAtlas(atlas_name)
+
+    # mock an additional reference for the example mouse
+    atlas_path = Path.home() / ".brainglobe" / "example_mouse_100um_v1.2"
+    metadata_path = atlas_path / "metadata.json"
+    if metadata_path.exists():
+        with open(metadata_path, "r") as f:
+            metadata = f.read()
+            metadata_dict = json.loads(metadata)
+            metadata_dict["additional_references"] = ["reference"]
+            with open(metadata_path, "w") as f:
+                json.dump(metadata_dict, f, indent=4)
 
 
 @pytest.fixture

--- a/tests/test_integration/test_brainrender_viewer_widget.py
+++ b/tests/test_integration/test_brainrender_viewer_widget.py
@@ -86,12 +86,14 @@ def test_add_additional_reference_selected(viewer_widget, mocker):
         "brainrender_napari.brainrender_viewer_widget"
         ".NapariAtlasRepresentation.add_additional_reference"
     )
-    viewer_widget.atlas_viewer_view.selectRow(5)  # mpin_zfish_1um is in row 5
+    viewer_widget.atlas_viewer_view.selectRow(
+        0
+    )  # # example atlas + mock additional reference is in row 0
     assert (
         viewer_widget.atlas_viewer_view.selected_atlas_name()
-        == "mpin_zfish_1um"
+        == "example_mouse_100um"
     )
-    additional_reference_name = "GAD1b"
+    additional_reference_name = "reference"
     viewer_widget.atlas_viewer_view.additional_reference_requested.emit(
         additional_reference_name
     )

--- a/tests/test_unit/test_atlas_manager_view.py
+++ b/tests/test_unit/test_atlas_manager_view.py
@@ -37,7 +37,7 @@ def test_update_atlas_confirmed(
 
     with qtbot.waitSignal(
         atlas_manager_view.update_atlas_confirmed,
-        timeout=150000,  # assumes atlas can be updated in 2.5 minutes!
+        timeout=300000,  # assumes atlas can be updated in 5 minutes!
     ) as update_atlas_confirmed_signal:
         # replace with double-click on view?
         model_index = atlas_manager_view.model().index(0, 0)
@@ -96,7 +96,7 @@ def test_download_confirmed_callback(atlas_manager_view, qtbot):
 
     with qtbot.waitSignal(
         atlas_manager_view.download_atlas_confirmed,
-        timeout=150000,  # assumes atlas can be installed in 2.5 minutes!
+        timeout=300000,  # assumes atlas can be installed in 5 minutes!
     ) as download_atlas_confirmed_signal:
         model_index = atlas_manager_view.model().index(0, 0)
         atlas_manager_view.setCurrentIndex(model_index)

--- a/tests/test_unit/test_atlas_viewer_view.py
+++ b/tests/test_unit/test_atlas_viewer_view.py
@@ -99,17 +99,19 @@ def test_double_click_on_locally_available_atlas_row(
 def test_additional_reference_menu(atlas_viewer_view, qtbot, mocker):
     """Checks callback to additional reference menu calls QMenu exec
     and emits expected signal"""
-    atlas_viewer_view.selectRow(5)  # mpin_zfish_1um is in row 5
+    atlas_viewer_view.selectRow(
+        0
+    )  # example atlas + mock additional reference is in row 0
     from qtpy.QtCore import QPoint
     from qtpy.QtWidgets import QAction
 
-    x = atlas_viewer_view.rowViewportPosition(5)
+    x = atlas_viewer_view.rowViewportPosition(0)
     y = atlas_viewer_view.columnViewportPosition(1)
     position = QPoint(x, y)
     qmenu_exec_mock = mocker.patch(
         "brainrender_napari.widgets.atlas_viewer_view.QMenu.exec"
     )
-    qmenu_exec_mock.return_value = QAction("mock_additional_reference")
+    qmenu_exec_mock.return_value = QAction("reference")
 
     with qtbot.waitSignal(
         atlas_viewer_view.additional_reference_requested
@@ -117,9 +119,7 @@ def test_additional_reference_menu(atlas_viewer_view, qtbot, mocker):
         atlas_viewer_view.customContextMenuRequested.emit(position)
 
     qmenu_exec_mock.assert_called_once()
-    assert additional_reference_requested_signal.args == [
-        "mock_additional_reference"
-    ]
+    assert additional_reference_requested_signal.args == ["reference"]
 
 
 def test_get_tooltip():

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -120,8 +120,8 @@ def test_structure_color(make_napari_viewer):
 
 def test_add_additional_reference(make_napari_viewer):
     viewer = make_napari_viewer()
-    atlas_name = "mpin_zfish_1um"
-    additional_reference_name = "GAD1b"
+    atlas_name = "example_mouse_100um"
+    additional_reference_name = "reference"
     atlas = BrainGlobeAtlas(atlas_name=atlas_name)
 
     atlas_representation = NapariAtlasRepresentation(atlas, viewer)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Tests were timing out weirdly, and spuriously on CI only, presumably because of connectivity issues.

**What does this PR do?**
Simplifies the tests by removing the fish atlas (which was there because we wanted tests for additional-reference related functionality), and implementing a manual mocking an additional reference for the example mouse atlas instead.

## References

Closes #158 

## How has this PR been tested?

Makes CI reliably pass again from what I can see.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
