### PR TITLE
move hover coords to pixel space

### DIFF
--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -126,13 +126,13 @@ class NapariAtlasRepresentation:
             self._tooltip.move(QCursor.pos().x() + 20, QCursor.pos().y() + 20)
             try:
                 structure_acronym = self.bg_atlas.structure_from_coords(
-                    cursor_position, microns=True, as_acronym=True
+                    cursor_position, microns=False, as_acronym=True
                 )
                 structure_name = self.bg_atlas.structures[structure_acronym][
                     "name"
                 ]
                 hemisphere = self.bg_atlas.hemisphere_from_coords(
-                    cursor_position, as_string=True, microns=True
+                    cursor_position, as_string=True, microns=False
                 ).capitalize()
                 tooltip_text = f"{structure_name} | {hemisphere}"
                 self._tooltip.setText(tooltip_text)

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -142,7 +142,7 @@ def test_add_additional_reference(make_napari_viewer):
 @pytest.mark.parametrize(
     "cursor_position, expected_tooltip_text",
     [
-        ((6500.0, 4298.5, 9057.6), "Caudoputamen | Left"),
+        ((65, 43, 91), "Caudoputamen | Left"),
         ((-1000, 0, 0), ""),  # outside image
     ],
 )


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**What does this PR do?**
Tooltip hovering should be in pixel space since 0.0.5 but it was left in micron space.
This PR moves the hovering tooltip to pixel space.

## References

Closes #167 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
