### PR TITLE
reduce number of calls to GIN, for performance

### DIFF
--- a/brainrender_napari/data_models/atlas_table_model.py
+++ b/brainrender_napari/data_models/atlas_table_model.py
@@ -30,9 +30,10 @@ class AtlasTableModel(QAbstractTableModel):
     def refresh_data(self) -> None:
         """Refresh model data by calling atlas API"""
         all_atlases = get_all_atlases_lastversions()
+        local_atlases = get_atlases_lastversions().keys()
         data = []
         for name, latest_version in all_atlases.items():
-            if name in get_atlases_lastversions().keys():
+            if name in local_atlases:
                 data.append(
                     [
                         name,

--- a/brainrender_napari/utils/formatting.py
+++ b/brainrender_napari/utils/formatting.py
@@ -1,11 +1,7 @@
-from brainglobe_atlasapi.list_atlases import get_all_atlases_lastversions
-
-
 def format_atlas_name(name: str) -> str:
     """Format an atlas name nicely.
     Assumes input in the form of atlas_name_in_snake_case_RESOLUTIONum,
     e.g. allen_mouse_100um"""
-    assert name in get_all_atlases_lastversions().keys(), "invalid atlas name!"
     formatted_name = name.split("_")
     formatted_name[0] = formatted_name[0].capitalize()
     formatted_name[-1] = f"({formatted_name[-1].split('um')[0]} \u03BCm)"


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**What does this PR do?**

When instantiating the table with all the atlases, the previous code was calling `get_all_atlases_last_versions` (and therefore making a request to GIN) several times per atlas. Now it's only done twice in total (once explicitly, and once inside `get_atlases_last_versions`. This should speed up the table instantiation, and therefore the opening of the widget significantly (from >20s to <1s on my local desktop machine).

## References

Closes #141 

## How has this PR been tested?

Local profiling and manual experimentation.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
