### PR TITLE
Color rows of atlas manager widget

### DIFF
--- a/brainrender_napari/data_models/atlas_table_model.py
+++ b/brainrender_napari/data_models/atlas_table_model.py
@@ -5,6 +5,7 @@ from brainglobe_atlasapi.list_atlases import (
 )
 from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt
 from qtpy.QtWidgets import QTableView
+from qtpy.QtGui import QBrush, QColor
 
 from brainrender_napari.utils.formatting import format_atlas_name
 
@@ -55,6 +56,20 @@ class AtlasTableModel(QAbstractTableModel):
         if role == Qt.ToolTipRole:
             hovered_atlas_name = self._data[index.row()][0]
             return self.view_type.get_tooltip_text(hovered_atlas_name)
+        if role == Qt.BackgroundRole:
+            local_version = self._data[index.row()][2]
+            if local_version == "n/a":
+                # Remote atlas: greyed out background
+                return QBrush(Qt.lightGray)
+            else:
+                latest_version = self._data[index.row()][3]
+                if local_version == latest_version:
+                    # Up-to-date atlas: normal background (default)
+                    return None
+                else:
+                    # Out-of-date atlas: amber background
+                    return QBrush(QColor(255, 191, 0))
+        return None
 
     def rowCount(self, index: QModelIndex = QModelIndex()):
         return len(self._data)

--- a/brainrender_napari/data_models/atlas_table_model.py
+++ b/brainrender_napari/data_models/atlas_table_model.py
@@ -4,8 +4,8 @@ from brainglobe_atlasapi.list_atlases import (
     get_local_atlas_version,
 )
 from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt
-from qtpy.QtWidgets import QTableView
 from qtpy.QtGui import QBrush, QColor
+from qtpy.QtWidgets import QTableView
 
 from brainrender_napari.utils.formatting import format_atlas_name
 


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**
- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To give an indication to the user of the state.

**What does this PR do?**
For a better UX, I colored the rows in atlas manager as follows

"normal" for locally available, up-to-date atlases
"amber" for out-of-date atlases
"greyed out" for remote atlases

<img width="1024" alt="Screenshot 2025-03-02 at 14 39 20" src="https://github.com/user-attachments/assets/141fe449-7b61-4773-bf74-3ac114a00423" />


## References

- It has been observed that scrolling through local Atlases causes heavy performance degradation.

Now, this issue has been resolved!

## How has this PR been tested?

By running the following command:

`pytest -v --color=yes --cov=brainrender_napari --cov-report=xml`

And it passed all the test cases.

## Is this a breaking change?

No, this PR does not introduce any breaking changes. It only optimizes the performance of the Atlas list view.

## Does this PR require an update to the documentation?

Not at this stage.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
