### PR TITLE
Add popup warning for 2D mesh display

### DIFF
--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -57,6 +57,17 @@ class NapariAtlasRepresentation:
 
         structure_name: the id or acronym of the structure.
         """
+        # If the viewer is in 2D mode, a warning popup is displayed and processing is interrupted
+        if self.viewer.dims.ndisplay == 2:
+            from qtpy.QtWidgets import QMessageBox
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
+            msg.setWindowTitle("You need a 3D mode")
+            msg.setText("Meshes will only show if the display is set to 3D.")
+            msg.setStandardButtons(QMessageBox.Ok)
+            msg.exec_()
+            return
+        
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
         scale = [1.0 / resolution for resolution in self.bg_atlas.resolution]
         color = self.bg_atlas.structures[structure_name]["rgb_triplet"]

--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -4,6 +4,7 @@ import numpy as np
 from brainglobe_atlasapi import BrainGlobeAtlas
 from meshio import Mesh
 from napari.settings import get_settings
+from napari.utils.notifications import show_info
 from napari.viewer import Viewer
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QCursor
@@ -57,17 +58,11 @@ class NapariAtlasRepresentation:
 
         structure_name: the id or acronym of the structure.
         """
-        # If the viewer is in 2D mode, a warning popup is displayed and processing is interrupted
+        # If the viewer is in 2D mode, a warning popup is
+        # displayed and processing is interrupted
         if self.viewer.dims.ndisplay == 2:
-            from qtpy.QtWidgets import QMessageBox
-            msg = QMessageBox()
-            msg.setIcon(QMessageBox.Warning)
-            msg.setWindowTitle("You need a 3D mode")
-            msg.setText("Meshes will only show if the display is set to 3D.")
-            msg.setStandardButtons(QMessageBox.Ok)
-            msg.exec_()
-            return
-        
+            show_info("Meshes will only show if the display is set to 3D.")
+
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
         scale = [1.0 / resolution for resolution in self.bg_atlas.resolution]
         color = self.bg_atlas.structures[structure_name]["rgb_triplet"]

--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -58,8 +58,6 @@ class NapariAtlasRepresentation:
 
         structure_name: the id or acronym of the structure.
         """
-        # If the viewer is in 2D mode, a warning popup is
-        # displayed and processing is interrupted
         if self.viewer.dims.ndisplay == 2:
             show_info("Meshes will only show if the display is set to 3D.")
 

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 from brainglobe_atlasapi import BrainGlobeAtlas
 from meshio import Mesh
@@ -115,36 +114,12 @@ def test_show_info_called_for_2D_and_not_3D(
     viewer = make_napari_viewer()
     viewer.dims.ndisplay = ndisplay
 
-    atlas = BrainGlobeAtlas(atlas_name="example_mouse_100um")
+    atlas = BrainGlobeAtlas(atlas_name="allen_mouse_100um")
     atlas_representation = NapariAtlasRepresentation(atlas, viewer)
 
-    # Dummy mesh to avoid errors in mesh addition.
-    dummy_mesh = Mesh(
-        points=np.zeros((1, 3)), cells=[("triangle", np.array([[0, 0, 0]]))]
-    )
-
-    # Patch bg_atlas.mesh_from_structure to return dummy_mesh.
-    mocker.patch.object(
-        atlas_representation.bg_atlas,
-        "mesh_from_structure",
-        return_value=dummy_mesh,
-    )
-
-    # "dummy_structure" make the key referenceable
-    atlas_representation.bg_atlas.__dict__["structures"] = {
-        "dummy_structure": {"rgb_triplet": [255, 255, 255]}
-    }
-    atlas_representation.bg_atlas.__dict__["acronym_to_id_map"] = {
-        "dummy_structure": "dummy_structure"
-    }
-
     # Patch show_info from napari notifications.
-    show_info_mock = mocker.patch(
-        "brainrender_napari.napari_atlas_representation.show_info"
-    )
-
-    # Call add_structure_to_viewer with the dummy structure.
-    atlas_representation.add_structure_to_viewer("dummy_structure")
+    show_info_mock = mocker.patch("brainrender_napari.napari_atlas_representation.show_info")
+    atlas_representation.add_structure_to_viewer("CP")
 
     if expected_called:
         show_info_mock.assert_called_once_with(

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -1,6 +1,5 @@
 import pytest
 from brainglobe_atlasapi import BrainGlobeAtlas
-from meshio import Mesh
 from napari.layers import Image, Labels
 from numpy import all, allclose
 from qtpy.QtCore import QEvent, QPoint, Qt
@@ -118,7 +117,9 @@ def test_show_info_called_for_2D_and_not_3D(
     atlas_representation = NapariAtlasRepresentation(atlas, viewer)
 
     # Patch show_info from napari notifications.
-    show_info_mock = mocker.patch("brainrender_napari.napari_atlas_representation.show_info")
+    show_info_mock = mocker.patch(
+        "brainrender_napari.napari_atlas_representation.show_info"
+    )
     atlas_representation.add_structure_to_viewer("CP")
 
     if expected_called:


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To address this [issue](https://github.com/brainglobe/brainrender-napari/issues/104) and indicate that meshes are only available in 3D.

**What does this PR do?**
- [x] A warning popup now pops up, like img below, when trying to use a mesh in 2D mode.
- [x] And added a new test code to make sure that a warning popup functions as expected.

<img width="1918" alt="Screenshot 2025-03-04 at 19 25 26" src="https://github.com/user-attachments/assets/32159954-eb71-40f4-8cc2-4e55d4c4ad54" />

## References

Please reference any existing issues/PRs that relate to this PR.
[issues/104](https://github.com/brainglobe/brainrender-napari/issues/104)
## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

by running following command:

`pytest -v --color=yes --cov=brainrender_napari --cov-report=xml`

and it passed all the test cases.

The new test function checkes below:

- [x] show_info is called when the viewer is in 2D mode
- [x] show_info is not called when the viewer is in 3D mode

## Is this a breaking change?
No
If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?
No
If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
