### PR TITLE
Add some kind of indication to show that data is being loaded in the background

### DIFF
--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -57,6 +57,17 @@ class NapariAtlasRepresentation:
 
         structure_name: the id or acronym of the structure.
         """
+        # If the viewer is in 2D mode, a warning popup is displayed and processing is interrupted
+        if self.viewer.dims.ndisplay == 2:
+            from qtpy.QtWidgets import QMessageBox
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
+            msg.setWindowTitle("You need a 3D mode")
+            msg.setText("Meshes will only show if the display is set to 3D.")
+            msg.setStandardButtons(QMessageBox.Ok)
+            msg.exec_()
+            return
+        
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
         scale = [1.0 / resolution for resolution in self.bg_atlas.resolution]
         color = self.bg_atlas.structures[structure_name]["rgb_triplet"]

--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -60,6 +60,7 @@ class NapariAtlasRepresentation:
         # If the viewer is in 2D mode, a warning popup is displayed and processing is interrupted
         if self.viewer.dims.ndisplay == 2:
             from qtpy.QtWidgets import QMessageBox
+
             msg = QMessageBox()
             msg.setIcon(QMessageBox.Warning)
             msg.setWindowTitle("You need a 3D mode")
@@ -67,7 +68,7 @@ class NapariAtlasRepresentation:
             msg.setStandardButtons(QMessageBox.Ok)
             msg.exec_()
             return
-        
+
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
         scale = [1.0 / resolution for resolution in self.bg_atlas.resolution]
         color = self.bg_atlas.structures[structure_name]["rgb_triplet"]


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description
Added some kind of indication to show that data is being loaded or uploaded in the background

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
For nicer UX, the indication to show that data is being loaded is useful 

**What does this PR do?**
Introduced an indicator to show how much data is being downloaded.

<img width="1321" alt="Screenshot 2025-03-04 at 2 15 17" src="https://github.com/user-attachments/assets/7672f8a8-8a24-477e-8979-fe5f8f5d31c2" />

## References

Please reference any existing issues/PRs that relate to this PR.

- [issue 112](https://github.com/brainglobe/brainrender-napari/issues/112)

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

I tested it by running the following command using the new test code

`pytest -v --color=yes --cov=brainrender_napari --cov-report=xml`

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.
No

## Does this PR require an update to the documentation?
Yes

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
