### PR TITLE
Add region name in 3D mesh

### DIFF
--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -69,7 +69,9 @@ class NapariAtlasRepresentation:
             color=color,
         )
 
-    def _add_mesh(self, mesh: Mesh, scale: list, name: str, region_name: str, color=None):
+    def _add_mesh(
+        self, mesh: Mesh, scale: list, name: str, region_name: str, color=None
+    ):
         """Helper function to add a mesh as a surface layer to the viewer.
 
         mesh: the mesh to add
@@ -91,7 +93,9 @@ class NapariAtlasRepresentation:
                 [[float(c) / 255 for c in color]], len(points), axis=0
             )
 
-        layer = self.viewer.add_surface((points, cells), scale=scale, **viewer_kwargs)
+        layer = self.viewer.add_surface(
+            (points, cells), scale=scale, **viewer_kwargs
+        )
         layer.metadata["region_name"] = region_name
 
     def add_additional_reference(self, additional_reference_key: str):
@@ -106,24 +110,30 @@ class NapariAtlasRepresentation:
 
     def _on_mouse_move(self, layer, event):
         """Adapts the tooltip according to the cursor position.
-    
         In 2D mode, it works as before.
-        In 3D mode, it attempts to retrieve region information based on the cursor position
+        In 3D mode, it attempts to retrieve region information
+        based on the cursor position
         and displays the formal region name.
         """
         cursor_position = self.viewer.cursor.position
         napari_settings = get_settings()
-        tooltip_visibility = napari_settings.appearance.layer_tooltip_visibility
+        tooltip_visibility = (
+            napari_settings.appearance.layer_tooltip_visibility
+        )
 
         if tooltip_visibility and np.all(np.array(cursor_position) > 0):
             # In the case of 2D
             if self.viewer.dims.ndisplay == 2:
-                self._tooltip.move(QCursor.pos().x() + 20, QCursor.pos().y() + 20)
+                self._tooltip.move(
+                    QCursor.pos().x() + 20, QCursor.pos().y() + 20
+                )
                 try:
                     structure_acronym = self.bg_atlas.structure_from_coords(
                         cursor_position, microns=False, as_acronym=True
                     )
-                    structure_name = self.bg_atlas.structures[structure_acronym]["name"]
+                    structure_name = self.bg_atlas.structures[
+                        structure_acronym
+                    ]["name"]
                     hemisphere = self.bg_atlas.hemisphere_from_coords(
                         cursor_position, as_string=True, microns=False
                     ).capitalize()
@@ -136,12 +146,16 @@ class NapariAtlasRepresentation:
                     self._tooltip.hide()
             # In the case of 3D
             elif self.viewer.dims.ndisplay == 3:
-                self._tooltip.move(QCursor.pos().x() + 20, QCursor.pos().y() + 20)
+                self._tooltip.move(
+                    QCursor.pos().x() + 20, QCursor.pos().y() + 20
+                )
                 try:
                     structure_acronym = self.bg_atlas.structure_from_coords(
                         cursor_position, microns=False, as_acronym=True
                     )
-                    structure_name = self.bg_atlas.structures[structure_acronym]["name"]
+                    structure_name = self.bg_atlas.structures[
+                        structure_acronym
+                    ]["name"]
                     tooltip_text = f"{structure_name}"
                     self._tooltip.setText(tooltip_text)
                     self._tooltip.adjustSize()


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
It would be nice if users could see the region name in 3D mesh mode.

**What does this PR do?**

- [x] Modified _on_mouse_move to get region name from the cursor's cordinates.
- [x] Added region name as metadata in surface layer

### Results 

<img width="1080" alt="Screenshot 2025-03-08 at 1 09 53" src="https://github.com/user-attachments/assets/3ab5d4f6-7041-4ce6-a8f7-41ce79e34959" />
<img width="1080" alt="Screenshot 2025-03-08 at 1 07 59" src="https://github.com/user-attachments/assets/dad187a3-e2dd-486b-8168-73408873cf43" />

## References

Please reference any existing issues/PRs that relate to this PR.

- [issues 97](https://github.com/brainglobe/brainrender-napari/issues/97)

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

By running the following command:
`pytest -v --color=yes --cov=brainrender_napari --cov-report=xml`

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.
No

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
