### PR TITLE
Simplify multi-threading around progressbar

### DIFF
--- a/brainrender_napari/widgets/atlas_manager_view.py
+++ b/brainrender_napari/widgets/atlas_manager_view.py
@@ -78,29 +78,33 @@ class AtlasManagerView(QTableView):
         """Downloads the currently selected atlas and signals this."""
         atlas_name = self.selected_atlas_name()
 
-        # Define update function directly
-        update_fn = lambda completed, total: self.progress_updated.emit(
-            completed, total, atlas_name, "Downloading"
+        worker = self._apply_in_thread(
+            install_atlas,
+            atlas_name,
+            fn_update=lambda completed, total: self.progress_updated.emit(
+                completed, total, atlas_name, "Downloading"
+            ),
         )
-
-        # Create worker, connect signal, and start worker
-        worker = self._apply_in_thread(install_atlas, atlas_name, fn_update=update_fn)
-        worker.returned.connect(lambda result: self.download_atlas_confirmed.emit(result))
-        worker.start()        
+        worker.returned.connect(
+            lambda result: self.download_atlas_confirmed.emit(result)
+        )
+        worker.start()
 
     def _on_update_atlas_confirmed(self):
         """Updates the currently selected atlas and signals this."""
         atlas_name = self.selected_atlas_name()
 
-        # Define update function directly
-        update_fn = lambda completed, total: self.progress_updated.emit(
-            completed, total, atlas_name, "Updating"
+        worker = self._apply_in_thread(
+            update_atlas,
+            atlas_name,
+            fn_update=lambda completed, total: self.progress_updated.emit(
+                completed, total, atlas_name, "Updating"
+            ),
         )
-
-        # Create worker, connect signal, and start worker
-        worker = self._apply_in_thread(update_atlas, atlas_name, fn_update=update_fn)
-        worker.returned.connect(lambda result: self.update_atlas_confirmed.emit(result))
-        worker.start()                
+        worker.returned.connect(
+            lambda result: self.update_atlas_confirmed.emit(result)
+        )
+        worker.start()
 
     def selected_atlas_name(self) -> str:
         """A single place to get a valid selected atlas name."""


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Because the implementation using `_start_worker` implemented in [this PR](https://github.com/brainglobe/brainrender-napari/pull/180) was complicated and difficult to understand the meaning.

**What does this PR do?**

1. Removed the _start_worker method entirely 
    This eliminates one level of abstraction that was adding complexity without providing significant benefits.

2. Used lambda functions directly in the confirmation methods 
    Instead of defining a separate member function, I've used `lambda functions` to create the update callback directly in the `_on_download_atlas_confirmed` and `_on_update_atlas_confirmed` methods.

3. Moved signal connections to the confirmation methods 
The signal connections now happen directly in each confirmation method, making the code flow clearer.

## References

Please reference any existing issues/PRs that relate to this PR.

- [Issues 190](https://github.com/brainglobe/brainrender-napari/issues/190)
- [PR 180](https://github.com/brainglobe/brainrender-napari/pull/180)

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

By running the following command:

`pytest -v --color=yes --cov=brainrender_napari --cov-report=xml`

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.
No
## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.
No
## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
