### PR TITLE
BRAINGLOBE_TEST_DIR support for configurable test directories (Addresses #28)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import json
-import tempfile
 import os
 import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -24,10 +24,12 @@ def mock_brainglobe_user_folders(monkeypatch):
     """
     if not os.getenv("GITHUB_ACTIONS"):
         home_path = Path.home()  # actual home path
-        
-        test_dir = os.getenv("BRAINGLOBE_TEST_DIR", home_path / ".brainglobe-tests")
+
+        test_dir = os.getenv(
+            "BRAINGLOBE_TEST_DIR", home_path / ".brainglobe-tests"
+        )
         mock_home_path = Path(test_dir)
-        
+
         if not mock_home_path.exists():
             mock_home_path.mkdir()
 
@@ -129,6 +131,7 @@ def mock_newer_atlas_version_available():
         shutil.rmtree(path=older_version_path)
         _ = BrainGlobeAtlas("example_mouse_100um")
     assert current_version_path.exists() and not older_version_path.exists()
+
 
 def test_brainglobe_test_dir_config(monkeypatch):
     """Test BRAINGLOBE_TEST_DIR environment variable override."""


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Currently, the test directories are hardcoded to `~/.brainglobe-tests`, which can causes permission issues on shared systems and makes CI pipeline cleanup harder. It also prevents any faults with parallel test execution. This means that users are restricted to using only specific file paths to run tests.

**What does this PR do?**

The PR can let the users choose where the test files go by setting an environment variable. It adds support for custom test directories via `BRAINGLOBE_TEST_DIR` env var. It also maintains backward compatibility with default path and includes simplified test validation to make sure it works. 

## References

This PR aims to assist with brainglobe/brainglobe-atlasapi#559 

## How has this PR been tested?

Unit Testing:
All of the testing was run using pytest and in a local environment. The implementation code was also was also tested to determine that no original functionality had been lost or changed.

## Is this a breaking change?

No as it maintains identical default behavior when no env var is set

## Does this PR require an update to the documentation?

Yes, most likely after a review and a follow up PR

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
