### PR TITLE
Add 'Clear' button to AtlasManagerFilter for resetting filters

### DIFF
--- a/brainrender_napari/widgets/atlas_manager_filter.py
+++ b/brainrender_napari/widgets/atlas_manager_filter.py
@@ -1,15 +1,14 @@
-from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QLineEdit, QWidget
+from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QLineEdit, QPushButton, QWidget
 
 from brainrender_napari.widgets.atlas_manager_view import AtlasManagerView
 
 
 class AtlasManagerFilter(QWidget):
     """Implements simple query-based filtering for the atlas table view,
-    allowing users to search for specific atlases."""
+    allowing users to search for specific atlases.
+    """
 
-    def __init__(
-        self, atlas_manager_view: AtlasManagerView, parent: QWidget = None
-    ):
+    def __init__(self, atlas_manager_view: AtlasManagerView, parent: QWidget = None):
         super().__init__(parent)
 
         self.atlas_manager_view = atlas_manager_view
@@ -30,9 +29,7 @@ class AtlasManagerFilter(QWidget):
         self.layout.addWidget(self.query_field)
 
         self.column_field = QComboBox()
-        self.column_field.addItems(
-            self.atlas_manager_view.source_model.column_headers
-        )
+        self.column_field.addItems(self.atlas_manager_view.source_model.column_headers)
         self.column_field.insertItem(0, "Any")
         for col in self.atlas_manager_view.hidden_columns:
             self.column_field.removeItem(self.column_field.findText(col))
@@ -41,26 +38,31 @@ class AtlasManagerFilter(QWidget):
 
         self.layout.addWidget(QLabel("Column:"))
         self.layout.addWidget(self.column_field)
+
+        # ✅ Add Clear button
+        self.clear_button = QPushButton("Clear", self)
+        self.clear_button.clicked.connect(self.clear_filter)
+        self.layout.addWidget(self.clear_button)
+
         return
 
     def apply(self):
-        """Updates proxy's internal state based on input and
-        applies filter."""
+        """Updates proxy's internal state based on input and applies filter."""
         query = self.query_field.text()
         column = self.column_field.currentText()
 
         if column == "Any":
             self.atlas_manager_view.proxy_model.setFilterKeyColumn(-1)
         else:
-            column_index = (
-                self.atlas_manager_view.source_model.column_headers.index(
-                    column
-                )
-            )
-            self.atlas_manager_view.proxy_model.setFilterKeyColumn(
-                column_index
-            )
+            column_index = self.atlas_manager_view.source_model.column_headers.index(column)
+            self.atlas_manager_view.proxy_model.setFilterKeyColumn(column_index)
 
         # apply filter
         self.atlas_manager_view.proxy_model.setFilterFixedString(query)
         return
+
+    def clear_filter(self):
+        """Clears both the query field and resets the column filter."""
+        self.query_field.clear()
+        self.column_field.setCurrentIndex(0)
+        self.apply()


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**


- [ ] Addition of a new feature


Added a "Clear" button to the AtlasManagerFilter widget in the brainrender-napari plugin, allowing users to quickly reset the search field and column filter.

Details:

Introduced a QPushButton labeled "Clear" in the UI layout.

Connected it to a new method clear_filter(), which:

Clears the text from the search field (QLineEdit)

Resets the column filter (QComboBox) to its default "Any" state

Reapplies the filter to update the view accordingly

This improves user experience by providing a convenient way to reset filters without manually deleting text or navigating the dropdown.



## References

Please reference any existing issues/PRs that relate to this PR.

functionality testing:
- The new "Clear" button functionality was tested manually within the running Napari plugin environment:

- Verified that clicking "Clear" resets the query field and column selection to their default states.

- Confirmed that the filter is immediately reapplied, returning the full unfiltered atlas list.

- Confirmed that other functionality (query typing, column selection) continues to behave as expected with no regressions.

- No errors or UI inconsistencies were observed during testing.


No, this is not a breaking change.



Does this PR require an update to the documentation?
- A minor update could be added to user-facing documentation describing the new "Clear" button in the filtering UI, if UI 
-  elements are documented in detail.

However, no core logic or API changes occurred that require documentation updates.

If there's a section explaining the AtlasManagerFilter, this new button can be noted for completeness.

(Optional: Link to the doc PR here, if created)

✅ Checklist:
 code has been tested locally
- Tests have been added to cover all new functionality (unit & integration)
- Note: Currently tested manually. No automated tests added due to the simplicity and UI-bound nature of the feature.

 The documentation has been updated to reflect any changes

Can be added if UI documentation exists for this widget.

 The code has been formatted with [pre-commit](https://pre-commit.com/)

Ran pre-commit or verified consistent formatting manually