### PR TITLE
Pins napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "brainglobe-atlasapi>=2.2.0",
     "brainglobe-utils>=0.4.3",
     "meshio",
-    "napari>=0.4.18",
+    "napari>=0.4.18,<0.6.0",
     "numpy",
     "qtpy",
 ]


### PR DESCRIPTION
Pinning napari<0.6.0. Can't instantiate a label layer from an array of uint32 dtype in napari==0.6.0.