### PR TITLE
Unpin napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "brainglobe-atlasapi>=2.2.0",
     "brainglobe-utils>=0.4.3",
     "meshio",
-    "napari>=0.4.18,<0.6.0",
+    "napari>=0.4.18,!=0.6.1",
     "numpy",
     "qtpy",
 ]


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix

**What does this PR do?**

Unpin napari. Instead, block 0.6.0.

0.6.1 should fix your issues with uint32 label creation. If it doesn't, please let us know! 

🍻 
