### PR TITLE
Bugfix: get correct index to download, when atlas manager view is filtered

### DIFF
--- a/brainrender_napari/widgets/atlas_manager_view.py
+++ b/brainrender_napari/widgets/atlas_manager_view.py
@@ -127,7 +127,7 @@ class AtlasManagerView(QTableView):
         selected_atlas_name_index: QModelIndex = (
             selected_index.siblingAtColumn(0)
         )
-        selected_atlas_name = self.source_model.data(selected_atlas_name_index)
+        selected_atlas_name = self.proxy_model.data(selected_atlas_name_index)
         return selected_atlas_name
 
     @thread_worker

--- a/tests/test_unit/test_atlas_manager_filter.py
+++ b/tests/test_unit/test_atlas_manager_filter.py
@@ -46,3 +46,10 @@ def test_filter_query(atlas_manager_view, query, data, column_name):
     atlas_manager_view.proxy_model.setFilterFixedString(query)
     atlas_manager_view.proxy_model.setFilterKeyColumn(column_index)
     assert atlas_manager_view.proxy_model.rowCount() == len(filtered_data)
+
+
+def test_filter_and_selected_name(atlas_manager_view):
+    atlas_manager_view.proxy_model.setFilterFixedString("kim_dev_mouse")
+    atlas_manager_view.proxy_model.setFilterKeyColumn(-1)
+    atlas_manager_view.selectRow(0)
+    assert "kim_dev_mouse" in atlas_manager_view.selected_atlas_name()


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**What does this PR do?**

Ensures users can download atlases after filtering the Atlas manager view.

## References

Closes #203 

## How has this PR been tested?

With test-driven development:
* I first added a new test for the bug, and checked that it failed locally
* I fixed the bug, and checked that this made the test pass

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
