### PR TITLE
Remove napari-hub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/brainrender-napari.svg?color=green)](https://python.org)
 [![tests](https://github.com/brainglobe/brainrender-napari/workflows/tests/badge.svg)](https://github.com/brainglobe/brainrender-napari/actions)
 [![codecov](https://codecov.io/gh/brainglobe/brainrender-napari/branch/main/graph/badge.svg)](https://codecov.io/gh/brainglobe/brainrender-napari)
-[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/brainrender-napari)](https://napari-hub.org/plugins/brainrender-napari)
 
 Visualisation and management of BrainGlobe atlases in napari.
 


### PR DESCRIPTION
Now that napari-hub is community maintained the https://api.napari-hub.org/shields/{package_name} endpoint is no longer valid.

Removing the badge for now.

Tracked in https://github.com/napari/hub-lite/issues/88 