### PR TITLE
Add hemisphere selector to filter region meshes by Left/Right/Both

### DIFF
--- a/brainrender_napari/brainrender_viewer_widget.py
+++ b/brainrender_napari/brainrender_viewer_widget.py
@@ -14,6 +14,7 @@ from brainglobe_utils.qtpy.logo import header_widget
 from napari.viewer import Viewer
 from qtpy.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QGroupBox,
     QVBoxLayout,
     QWidget,
@@ -24,8 +25,6 @@ from brainrender_napari.napari_atlas_representation import (
 )
 from brainrender_napari.widgets.atlas_viewer_view import AtlasViewerView
 from brainrender_napari.widgets.structure_view import StructureView
-
-from qtpy.QtWidgets import QComboBox , QLabel
 
 
 class BrainrenderViewerWidget(QWidget):
@@ -58,11 +57,11 @@ class BrainrenderViewerWidget(QWidget):
 
         self.show_structure_names = QCheckBox()
 
-        # defining the hemisphere selector 
-        self.hemisphere_selector=QComboBox()
-        self.hemisphere_selector.addItems(["Both","Left","Right"])
+        # defining the hemisphere selector
+        self.hemisphere_selector = QComboBox()
+        self.hemisphere_selector.addItems(["Both", "Left", "Right"])
         self.hemisphere_selector.setToolTip("Filter regions by hemisphere")
-        self.selected_hemisphere="Both"
+        self.selected_hemisphere = "Both"
 
         self.show_structure_names.setChecked(False)
         self.show_structure_names.setText("Show region names")
@@ -94,7 +93,7 @@ class BrainrenderViewerWidget(QWidget):
         self.structure_tree_group.layout().addWidget(self.show_structure_names)
         self.structure_tree_group.layout().addWidget(self.structure_view)
 
-        # displaying the hemisphere selector 
+        # displaying the hemisphere selector
         self.structure_tree_group.layout().addWidget(self.hemisphere_selector)
 
         self.structure_tree_group.hide()
@@ -117,9 +116,8 @@ class BrainrenderViewerWidget(QWidget):
         )
 
         self.hemisphere_selector.currentTextChanged.connect(
-        self._on_hemisphere_changed
+            self._on_hemisphere_changed
         )
-        
 
         # connect structure view signals
         self.structure_view.add_structure_requested.connect(
@@ -129,16 +127,14 @@ class BrainrenderViewerWidget(QWidget):
     def _on_add_structure_requested(self, structure_name: str) -> None:
         """Add given structure as napari atlas representation"""
         selected_atlas = BrainGlobeAtlas(
-        atlas_name=self.atlas_viewer_view.selected_atlas_name()
+            atlas_name=self.atlas_viewer_view.selected_atlas_name()
         )
         selected_atlas_representation = NapariAtlasRepresentation(
             bg_atlas=selected_atlas, viewer=self._viewer
         )
         selected_atlas_representation.add_structure_to_viewer(
-            structure_name,
-            hemisphere=self.selected_hemisphere
+            structure_name, hemisphere=self.selected_hemisphere
         )
-
 
         selected_atlas = BrainGlobeAtlas(
             atlas_name=self.atlas_viewer_view.selected_atlas_name()
@@ -185,6 +181,7 @@ class BrainrenderViewerWidget(QWidget):
             atlas_name,
             show_structure_names,
         )
+
     def _on_hemisphere_changed(self, hemisphere: str) -> None:
         self.selected_hemisphere = hemisphere
         print(f"Hemisphere selected: {hemisphere}")

--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -53,8 +53,9 @@ class NapariAtlasRepresentation:
         annotation.mouse_move_callbacks.append(self._on_mouse_move)
         reference.mouse_move_callbacks.append(self._on_mouse_move)
 
-    def add_structure_to_viewer(self, structure_name: str, hemisphere: str = "Both") -> None:
-
+    def add_structure_to_viewer(
+        self, structure_name: str, hemisphere: str = "Both"
+    ) -> None:
         """Adds the mesh of a structure to the viewer.
         The mesh will be rescaled to pixel space.
 
@@ -69,8 +70,6 @@ class NapariAtlasRepresentation:
             return
         else:
             print(f"Rendering {structure_name}")
-
-
 
         if self.viewer.dims.ndisplay == 2:
             show_info("Meshes will only show if the display is set to 3D.")


### PR DESCRIPTION
**Summary**

This PR adds a dropdown selector to filter brain region meshes by hemisphere (Both / Left / Right) in the brainrender-napari plugin.

**How it Works**

Adds a QComboBox to the plugin UI to let users select hemisphere

Filters region names using _L and _R suffixes before rendering

Skips any region that doesn’t match the selected hemisphere

**Testing**

Plugin loads and dropdown renders

When "Right" is selected, only _R meshes are added

When "Left" is selected, only _L meshes are added

"Both" allows all meshes

**Note**

The Allen mouse atlas does not use _L / _R suffixes, so manual testing was done with logging to confirm logic works.

Closes #145
