### PR TITLE
Fix loading atlas structures with user-configured brainglobe_dir

### DIFF
--- a/brainrender_napari/utils/load_user_data.py
+++ b/brainrender_napari/utils/load_user_data.py
@@ -1,8 +1,7 @@
 import json
-from pathlib import Path
 
-from brainglobe_atlasapi.list_atlases import get_local_atlas_version
 from brainglobe_atlasapi import config
+from brainglobe_atlasapi.list_atlases import get_local_atlas_version
 
 
 def read_atlas_metadata_from_file(atlas_name: str):


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- When users configure a custom ```brainglobe_dir``` via the config file, ```brainrender-napari``` correctly lists atlases, but fails to load structures because the code assumes default ```~/.brainglobe``` path.

**What does this PR do?**
- It updates atlas metadata and structure loading to use the user-configured ```brainglobe directory``` via ```config.get_brainglobe_dir()```, ensuring atlas files are loaded from the correct location.

## References
- Fixes #165 

## How has this PR been tested?
- Tested locally by setting a custom ```brainglobe_dir```.

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
