### PR TITLE
refactor(structure_tree): consolidate StructureTreeModel into data_models and remove duplicate widget implementation

### DIFF
--- a/brainrender_napari/widgets/structure_view.py
+++ b/brainrender_napari/widgets/structure_view.py
@@ -2,17 +2,15 @@
 model and view classes for the structures that form part of an atlas.
 The view is only visible if the atlas is downloaded."""
 
-
 from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
-from qtpy.QtCore import QModelIndex, Qt, Signal
+from qtpy.QtCore import QModelIndex, Signal
 from qtpy.QtWidgets import QTreeView, QWidget
-
-from brainrender_napari.utils.load_user_data import (
-    read_atlas_structures_from_file,
-)
 
 from brainrender_napari.data_models.structure_tree_model import (
     StructureTreeModel,
+)
+from brainrender_napari.utils.load_user_data import (
+    read_atlas_structures_from_file,
 )
 
 

--- a/brainrender_napari/widgets/structure_view.py
+++ b/brainrender_napari/widgets/structure_view.py
@@ -2,158 +2,18 @@
 model and view classes for the structures that form part of an atlas.
 The view is only visible if the atlas is downloaded."""
 
-from typing import Dict, List
 
 from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
-from brainglobe_atlasapi.structure_tree_util import get_structures_tree
-from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal
-from qtpy.QtGui import QStandardItem
+from qtpy.QtCore import QModelIndex, Qt, Signal
 from qtpy.QtWidgets import QTreeView, QWidget
 
 from brainrender_napari.utils.load_user_data import (
     read_atlas_structures_from_file,
 )
 
-
-class StructureTreeItem(QStandardItem):
-    """A class to hold items in a tree model."""
-
-    def __init__(self, data, parent=None) -> None:
-        self.parent_item = parent
-        self.item_data = data
-        self.child_items: List[StructureTreeItem] = []
-
-    def appendChild(self, item) -> None:
-        self.child_items.append(item)
-
-    def child(self, row):
-        return self.child_items[row]
-
-    def childCount(self) -> int:
-        return len(self.child_items)
-
-    def columnCount(self) -> int:
-        return len(self.item_data)
-
-    def data(self, column):
-        try:
-            return self.item_data[column]
-        except IndexError:
-            return None
-
-    def parent(self):
-        return self.parent_item
-
-    def row(self):
-        if self.parent_item:
-            return self.parent_item.child_items.index(self)
-        return 0
-
-
-class StructureTreeModel(QAbstractItemModel):
-    """Implementation of a read-only QAbstractItemModel to hold
-    the structure tree information provided by the Atlas API in a Qt Model"""
-
-    def __init__(self, data: List, parent=None) -> None:
-        super().__init__()
-        self.root_item = StructureTreeItem(data=("acronym", "name", "id"))
-        self.build_structure_tree(data, self.root_item)
-
-    def build_structure_tree(
-        self, structures: List, root: StructureTreeItem
-    ) -> None:
-        """Build the structure tree given a list of structures."""
-        tree = get_structures_tree(structures)
-        structure_id_dict = {}
-        for structure in structures:
-            structure_id_dict[structure["id"]] = structure
-
-        inserted_items: Dict[str, StructureTreeItem] = {}
-        for n_id in tree.expand_tree():  # sorts nodes by default,
-            # so parents will always be already in the QAbstractItemModel
-            # before their children
-            node = tree.get_node(n_id)
-            acronym = structure_id_dict[node.identifier]["acronym"]
-            name = structure_id_dict[node.identifier]["name"]
-            if (
-                len(structure_id_dict[node.identifier]["structure_id_path"])
-                == 1
-            ):
-                parent_item = root
-            else:
-                parent_id: str = tree.parent(node.identifier).identifier
-                parent_item = inserted_items[parent_id]
-
-            item = StructureTreeItem(
-                data=(acronym, name, node.identifier), parent=parent_item
-            )
-            parent_item.appendChild(item)
-            inserted_items[node.identifier] = item
-
-    def data(self, index: QModelIndex, role=Qt.DisplayRole):
-        """Provides read-only data for a given index if
-        intended for display, otherwise None."""
-        if not index.isValid():
-            return None
-
-        if role != Qt.DisplayRole:
-            return None
-
-        item = index.internalPointer()
-
-        return item.data(index.column())
-
-    def rowCount(self, parent: StructureTreeItem):
-        """Returns the number of rows(i.e. children) of an item"""
-        if parent.column() > 0:
-            return 0
-
-        if not parent.isValid():
-            parent_item = self.root_item
-        else:
-            parent_item = parent.internalPointer()
-
-        return parent_item.childCount()
-
-    def columnCount(self, parent: StructureTreeItem):
-        """The number of columns of an item."""
-        if parent.isValid():
-            return parent.internalPointer().columnCount()
-        else:
-            return self.root_item.columnCount()
-
-    def parent(self, index: QModelIndex) -> QModelIndex:
-        """The first-column index of parent of the item
-        at a given index. Returns an empty index if the root,
-        or an invalid index, is passed.
-        """
-        if not index.isValid():
-            return QModelIndex()
-
-        child_item = index.internalPointer()
-        parent_item = child_item.parent()
-
-        if parent_item == self.root_item:
-            return QModelIndex()
-
-        return self.createIndex(parent_item.row(), 0, parent_item)
-
-    def index(self, row, column, parent=QModelIndex()) -> QModelIndex:
-        """The index of the item at (row, column) with a given parent.
-        By default, the given parent is assumed to be the root."""
-        if not self.hasIndex(row, column, parent):
-            return QModelIndex()
-
-        if not parent.isValid():
-            parent_item: StructureTreeItem = self.root_item
-        else:
-            parent_item = parent.internalPointer()
-
-        child_item = parent_item.child(row)
-        if child_item:
-            return self.createIndex(row, column, child_item)
-        else:
-            return QModelIndex()
+from brainrender_napari.data_models.structure_tree_model import (
+    StructureTreeModel,
+)
 
 
 class StructureView(QTreeView):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other (refactor)

**Why is this PR needed?**

The structure tree model (`StructureTreeModel` and `StructureTreeItem`) was previously defined in both `data_models/structure_tree_model.py` and `widgets/structure_view.py`. This duplication increased maintenance
overhead and risk of inconsistent behaviour.

**What does this PR do?**

- Removes duplicate model implementation from `structure_view.py`
- Uses the canonical implementation from `data_models/structure_tree_model.py`
- Updates imports to ensure a single source of truth for the structure tree model

## References

Fixes: #232 

## How has this PR been tested?

- Tested locally using napari
- Verified atlas loads successfully
- Structure tree renders, expands, and selection works as expected
- Confirmed no runtime errors after refactor

## Is this a breaking change?

No. This refactor does not change public APIs or user-facing behaviour.

## Does this PR require an update to the documentation?

No documentation changes are required as functionality remains unchanged.

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with pre-commit