### PR TITLE
fix incorrect definition of __all__ in __init__.py file

### DIFF
--- a/brainrender_napari/__init__.py
+++ b/brainrender_napari/__init__.py
@@ -1,4 +1,6 @@
 __version__ = "0.0.1"
 
+from .brainrender_viewer_widget import BrainrenderViewerWidget
+from .brainrender_manager_widget import BrainrenderManagerWidget
 
-__all__ = "BrainrenderViewerWidget, BrainrenderManagerWidget"
+__all__ = ("BrainrenderViewerWidget", "BrainrenderManagerWidget")


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`__all__` in `brainrender-napari/__init__.py` was defined as a string rather than a list. Defining it as a string does not follow standard conventions and lead to import errors when using `from brainrender_napari import *` in python shell when i tested in terminal. This is much needed for developers using python shell to interact with napari viewer.
Also, the widget classes were not imported at package level, which makes public imports inconsistent.

**What does this PR do?**

- convert `__all__` variable to a list of strings.
- explicitly imports the public widget classes in the `__init__.py` file.
- Aligns the expected package behaviour with standard practices.

## References

None

## How has this PR been tested?

Locally verified that widgets imported correctly. Running ` from brainrender_napari import * ` in the python shell works without import errors. Launched and tested napari in the shell using `napari.Viewer()`  to ensure plugin behaviour remain the same.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
