### PR TITLE
Fix tooltip text color for napari

### DIFF
--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -29,7 +29,6 @@ class NapariAtlasRepresentation:
         )
         self._tooltip.setAttribute(Qt.WA_ShowWithoutActivating)
         self._tooltip.setAlignment(Qt.AlignCenter)
-        self._tooltip.setStyleSheet("color: black")
         napari_settings = get_settings()
         napari_settings.appearance.layer_tooltip_visibility = True
 


### PR DESCRIPTION
## Description

Fixes the issue where cursor tooltip text appears as dark text on a dark background in napari dark mode.

The problem was caused by a hardcoded stylesheet:

    self._tooltip.setStyleSheet("color: black")

This prevented Qt/napari from adapting the tooltip text color according to the active theme.

### Changes
Removed the hardcoded tooltip text color.

### Result
Tooltips now correctly adapt to dark mode.

Fixes #215