### PR TITLE
Remove specific backend specification in dev optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
   "pre-commit",
   "ruff",
   "setuptools_scm",
-  "napari[all]"
+  "napari[all]>=0.6.1"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
   "pre-commit",
   "ruff",
   "setuptools_scm",
-  "pyqt5"
+  "napari[all]"
 ]
 
 [build-system]

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -2,7 +2,7 @@ import pytest
 from brainglobe_atlasapi import BrainGlobeAtlas
 from napari.layers import Image, Labels
 from numpy import all, allclose
-from qtpy.QtCore import QEvent, QPoint, Qt
+from qtpy.QtCore import QEvent, QPointF, Qt
 from qtpy.QtGui import QMouseEvent
 
 from brainrender_napari.napari_atlas_representation import (
@@ -188,8 +188,8 @@ def test_viewer_tooltip(
     annotation = viewer.layers[1]
 
     event = QMouseEvent(
-        QEvent.MouseMove,
-        QPoint(0, 0),  # any pos will do to check text
+        QEvent.Type.MouseMove,
+        QPointF(0, 0),  # any pos will do to check text
         Qt.MouseButton.NoButton,
         Qt.MouseButton.NoButton,
         Qt.KeyboardModifier.NoModifier,
@@ -214,8 +214,8 @@ def test_too_quick_mouse_move_keyerror(make_napari_viewer, mocker):
     annotation = viewer.layers[1]
 
     event = QMouseEvent(
-        QEvent.MouseMove,
-        QPoint(0, 0),  # any pos will do to check text
+        QEvent.Type.MouseMove,
+        QPointF(0, 0),  # any pos will do to check text
         Qt.MouseButton.NoButton,
         Qt.MouseButton.NoButton,
         Qt.KeyboardModifier.NoModifier,


### PR DESCRIPTION
Removes `pyqt5` from the dev optional dependencies to instead rely on `napari[all]` to supply the default backend.