### PR TITLE
Show annotation on top of visible reference image

### DIFF
--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -36,18 +36,20 @@ class NapariAtlasRepresentation:
     def add_to_viewer(self) -> None:
         """Adds the reference and annotation images as layers to the viewer.
 
-        The layers are connected to the mouse move callback to set tooltip.
-        The reference image's visibility is off, the annotation's is on.
+        The annotation layer is partially transparent.
+        The annotation layer is displayed above the reference layer.
+
+        The layers are connected to the mouse move callback to setup tooltip.
         """
         reference = self.viewer.add_image(
             self.bg_atlas.reference,
             name=f"{self.bg_atlas.atlas_name}_reference",
-            visible=False,
         )
 
         annotation = self.viewer.add_labels(
             self.bg_atlas.annotation,
             name=f"{self.bg_atlas.atlas_name}_annotation",
+            opacity=0.33,
         )
 
         annotation.mouse_move_callbacks.append(self._on_mouse_move)

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -22,7 +22,8 @@ from brainrender_napari.napari_atlas_representation import (
 def test_add_to_viewer(make_napari_viewer, expected_atlas_name, anisotropic):
     """Checks that calling add_to_viewer() adds the expected number of
     layers, of the expected type and with the expected name.
-    Also checks that reference and annotation image have the same extents.
+    Also checks that reference and annotation image have the same extents,
+    and layers have the expected visibility and opacity.
     """
     viewer = make_napari_viewer()
     atlas = BrainGlobeAtlas(atlas_name=expected_atlas_name)
@@ -50,7 +51,12 @@ def test_add_to_viewer(make_napari_viewer, expected_atlas_name, anisotropic):
     assert reference.name == f"{expected_atlas_name}_reference"
 
     assert isinstance(annotation, Labels)
+    assert annotation.visible
+    assert annotation.opacity == 0.33
+
     assert isinstance(reference, Image)
+    assert reference.visible
+    assert reference.opacity == 1.0
 
     assert (
         atlas_representation._on_mouse_move in annotation.mouse_move_callbacks


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We decided to slightly change the default behaviour of adding atlases to the viewer in #249 

**What does this PR do?**
This PR 
* adds the code changes ensuring double-clicking on an atlas will show both reference and annotation image, with annotation above the reference at 33% opacity.
* adapts docstrings accordingly
* adapts and adds to the existing unit test for `NapariAtlasRepresentation.add_to_viewer` accordingly

## References

Closes #249 

## How has this PR been tested?

Tests pass locally, and cover the changes.
Also visually inspected (33% looked better than 50% opacity in my opinion).

## Is this a breaking change?

Yes. Behaviour changes slightly, impacting the UX.

## Does this PR require an update to the documentation?

Yes, to be addressed in https://github.com/brainglobe/brainglobe.github.io/issues/485

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [in progress] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
