### PR TITLE
feat: let users set a custom colour for structure meshes

### DIFF
--- a/brainrender_napari/brainrender_viewer_widget.py
+++ b/brainrender_napari/brainrender_viewer_widget.py
@@ -14,6 +14,7 @@ from brainglobe_utils.qtpy.logo import header_widget
 from napari.viewer import Viewer
 from qtpy.QtWidgets import (
     QCheckBox,
+    QColorDialog,
     QGroupBox,
     QVBoxLayout,
     QWidget,
@@ -77,6 +78,7 @@ class BrainrenderViewerWidget(QWidget):
         self.structure_tree_group = QGroupBox("3D Atlas region meshes")
         self.structure_tree_group.setToolTip(
             "Double-click on an atlas region to add its mesh to the viewer.\n"
+            "Right-click a region to add it with a custom colour.\n"
             "Meshes will only show if the display is set to 3D.\n"
             "Toggle 2D/3D display using the square/cube icon on the\n"
             "lower left of the napari window."
@@ -107,28 +109,50 @@ class BrainrenderViewerWidget(QWidget):
         self.structure_view.add_structure_requested.connect(
             self._on_add_structure_requested
         )
+        self.structure_view.add_structure_with_color_requested.connect(
+            self._on_add_structure_with_color_requested
+        )
 
-    def _on_add_structure_requested(self, structure_name: str) -> None:
-        """Add given structure as napari atlas representation"""
+    def _selected_atlas_representation(self) -> NapariAtlasRepresentation:
+        """Build a representation for the currently selected atlas."""
         selected_atlas = BrainGlobeAtlas(
             atlas_name=self.atlas_viewer_view.selected_atlas_name()
         )
-        selected_atlas_representation = NapariAtlasRepresentation(
+        return NapariAtlasRepresentation(
             bg_atlas=selected_atlas, viewer=self._viewer
         )
-        selected_atlas_representation.add_structure_to_viewer(structure_name)
+
+    def _on_add_structure_requested(self, structure_name: str) -> None:
+        """Add given structure as napari atlas representation"""
+        self._selected_atlas_representation().add_structure_to_viewer(
+            structure_name
+        )
+
+    def _on_add_structure_with_color_requested(
+        self, structure_name: str
+    ) -> None:
+        """Add given structure with a user-chosen colour.
+
+        Opens a colour picker; if the user confirms a colour, the structure
+        mesh is added with that colour. If the user cancels, nothing happens
+        and the structure is not added.
+        """
+        chosen_color = QColorDialog.getColor()
+        if chosen_color.isValid():
+            self._selected_atlas_representation().add_structure_to_viewer(
+                structure_name,
+                color=[
+                    chosen_color.red(),
+                    chosen_color.green(),
+                    chosen_color.blue(),
+                ],
+            )
 
     def _on_additional_reference_requested(
         self, additional_reference_name: str
     ) -> None:
         """Add additional reference as napari atlas representation"""
-        atlas = BrainGlobeAtlas(
-            atlas_name=self.atlas_viewer_view.selected_atlas_name()
-        )
-        atlas_representation = NapariAtlasRepresentation(
-            bg_atlas=atlas, viewer=self._viewer
-        )
-        atlas_representation.add_additional_reference(
+        self._selected_atlas_representation().add_additional_reference(
             additional_reference_name
         )
 

--- a/brainrender_napari/napari_atlas_representation.py
+++ b/brainrender_napari/napari_atlas_representation.py
@@ -55,18 +55,21 @@ class NapariAtlasRepresentation:
         annotation.mouse_move_callbacks.append(self._on_mouse_move)
         reference.mouse_move_callbacks.append(self._on_mouse_move)
 
-    def add_structure_to_viewer(self, structure_name: str) -> None:
+    def add_structure_to_viewer(self, structure_name: str, color=None) -> None:
         """Adds the mesh of a structure to the viewer.
         The mesh will be rescaled to pixel space.
 
         structure_name: the id or acronym of the structure.
+        color: RGB values (0-255) as a list to colour the mesh with.
+            If None, the atlas' default colour for the structure is used.
         """
         if self.viewer.dims.ndisplay == 2:
             show_info("Meshes will only show if the display is set to 3D.")
 
         mesh = self.bg_atlas.mesh_from_structure(structure_name)
         scale = [1.0 / resolution for resolution in self.bg_atlas.resolution]
-        color = self.bg_atlas.structures[structure_name]["rgb_triplet"]
+        if color is None:
+            color = self.bg_atlas.structures[structure_name]["rgb_triplet"]
         self._add_mesh(
             mesh,
             scale,

--- a/brainrender_napari/widgets/structure_view.py
+++ b/brainrender_napari/widgets/structure_view.py
@@ -8,7 +8,7 @@ from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
 from brainglobe_atlasapi.structure_tree_util import get_structures_tree
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal
 from qtpy.QtGui import QStandardItem
-from qtpy.QtWidgets import QTreeView, QWidget
+from qtpy.QtWidgets import QMenu, QTreeView, QWidget
 
 from brainrender_napari.utils.load_user_data import (
     read_atlas_structures_from_file,
@@ -158,10 +158,16 @@ class StructureTreeModel(QAbstractItemModel):
 
 class StructureView(QTreeView):
     add_structure_requested = Signal(str)
+    add_structure_with_color_requested = Signal(str)
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
         self.doubleClicked.connect(self._on_row_double_clicked)
+
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(
+            self._on_context_menu_requested
+        )
 
         def resize_acronym_column():
             self.resizeColumnToContents(0)
@@ -200,6 +206,27 @@ class StructureView(QTreeView):
         acronym_index = selected_index.siblingAtColumn(0)
         selected_structure_acronym = self.model().data(acronym_index)
         return selected_structure_acronym
+
+    def _on_context_menu_requested(self, position) -> None:
+        """Shows a context menu to add the currently selected structure
+        with a user-defined colour. Does nothing if no valid structure
+        is selected.
+        """
+        selected_index = self.selectionModel().currentIndex()
+        if not selected_index.isValid():
+            return
+
+        global_position = self.viewport().mapToGlobal(position)
+        context_menu = QMenu()
+        add_with_color_action = context_menu.addAction(
+            "Add region with custom colour…"
+        )
+
+        selected_action = context_menu.exec(global_position)
+        if selected_action == add_with_color_action:
+            self.add_structure_with_color_requested.emit(
+                self.selected_structure_acronym()
+            )
 
     def _on_row_double_clicked(self):
         self.add_structure_requested.emit(self.selected_structure_acronym())

--- a/tests/test_unit/test_napari_atlas_representation.py
+++ b/tests/test_unit/test_napari_atlas_representation.py
@@ -153,6 +153,26 @@ def test_structure_color(make_napari_viewer):
         assert a * 255 == e
 
 
+def test_structure_color_override(make_napari_viewer):
+    """Checks that a user-supplied colour overrides the atlas default
+    and is propagated to the corresponding napari layer.
+    """
+    viewer = make_napari_viewer()
+    atlas = BrainGlobeAtlas(atlas_name="example_mouse_100um")
+
+    atlas_representation = NapariAtlasRepresentation(atlas, viewer)
+    custom_RGB = [10, 20, 30]
+    # sanity check: the custom colour differs from the atlas default,
+    # so the test genuinely exercises the override
+    assert atlas.structures["root"]["rgb_triplet"] != custom_RGB
+
+    atlas_representation.add_structure_to_viewer("root", color=custom_RGB)
+    actual_rgb = viewer.layers[0].vertex_colors[0]
+
+    for a, e in zip(actual_rgb, custom_RGB):
+        assert a * 255 == e
+
+
 def test_add_additional_reference(make_napari_viewer):
     viewer = make_napari_viewer()
     atlas_name = "example_mouse_100um"


### PR DESCRIPTION
## Summary

Adds a way for users to choose the colour of a structure mesh, addressing #46.
Previously structure meshes were always added using the atlas' default
`rgb_triplet`, with no way to override it.

## What changed

- **`NapariAtlasRepresentation.add_structure_to_viewer`** now takes an optional
  `color` argument. When it is `None` (the default) the atlas' built-in colour is
  used exactly as before, so existing behaviour is unchanged.
- **`StructureView`** gains a right-click context menu with an
  *"Add region with custom colour…"* action, which emits a new
  `add_structure_with_color_requested` signal. This mirrors the existing
  right-click idiom already used in `AtlasViewerView` for additional references.
- **`BrainrenderViewerWidget`** connects that signal to a handler that opens a
  `QColorDialog`; if the user confirms a colour the mesh is added with it, and if
  they cancel nothing happens. The shared "build a representation for the selected
  atlas" logic was pulled into a small `_selected_atlas_representation` helper to
  avoid duplication.
- The region group tooltip now mentions the right-click option for discoverability.

## Behaviour

- **Double-click** a region → added with the atlas' default colour (unchanged).
- **Right-click** a region → pick a colour → added with that colour.

## Tests

Added `test_structure_color_override`, which adds a structure with an explicit
`color` and asserts the resulting surface layer's per-vertex colours match the
chosen RGB (and that it differs from the atlas default). Existing structure /
additional-reference tests and the `StructureView` tests still pass; pre-commit
(black, ruff, mypy, …) is clean.

## Note for reviewers

I went with a right-click → colour-dialog flow to match the existing
additional-reference context menu, and kept double-click as the unchanged default.
Happy to adjust the UX (e.g. a persistent colour swatch, or applying a colour to
the default double-click action) if you'd prefer a different approach.

Closes #46
